### PR TITLE
feat: Add auto-close inactive tabs feature with configurable timer

### DIFF
--- a/TabCap Extension/manifest.json
+++ b/TabCap Extension/manifest.json
@@ -20,6 +20,6 @@
       "128": "images/icon-128.png"
     }
   },
-  "permissions": ["tabs", "storage"],
+  "permissions": ["tabs", "storage", "alarms"],
   "web_accessible_resources": []
 }

--- a/TabCap Extension/popup.css
+++ b/TabCap Extension/popup.css
@@ -875,6 +875,89 @@ body {
   filter: brightness(1.1);
 }
 
+/* Inactive Tabs */
+.inactive-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  opacity: 0.5;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.inactive-settings.enabled {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.inactive-tabs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.inactive-tab-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.625rem;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 0.75rem;
+}
+
+.inactive-tab-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.inactive-tab-title {
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.inactive-tab-time {
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+}
+
+.inactive-tab-badge {
+  font-size: 0.625rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-weight: 600;
+  white-space: nowrap;
+  margin-left: 0.5rem;
+}
+
+.inactive-tab-badge.safe {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--success);
+}
+
+.inactive-tab-badge.warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
+}
+
+.inactive-tab-badge.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
+}
+
+.inactive-tab-badge.protected {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--accent);
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 4px;

--- a/TabCap Extension/popup.css
+++ b/TabCap Extension/popup.css
@@ -527,6 +527,34 @@ body {
   color: var(--text-secondary);
 }
 
+/* Select Input */
+.select-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23737373' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+}
+
+.select-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.select-input option {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
 /* Allowlist */
 .allowlist-container {
   display: flex;

--- a/TabCap Extension/popup.css
+++ b/TabCap Extension/popup.css
@@ -498,13 +498,33 @@ body {
   transform: scale(0.95);
 }
 
-.stepper-value {
-  min-width: 28px;
+.stepper-value,
+.stepper-input {
+  min-width: 40px;
+  width: 40px;
   text-align: center;
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--accent);
   transition: color 0.2s ease;
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  padding: 0;
+}
+
+.stepper-input:focus {
+  outline: none;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+}
+
+/* Hide spin buttons */
+.stepper-input::-webkit-inner-spin-button,
+.stepper-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 /* Info Box */

--- a/TabCap Extension/popup.css
+++ b/TabCap Extension/popup.css
@@ -922,8 +922,13 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  max-height: 120px;
+  max-height: 180px; /* Restored to full height */
   overflow-y: auto;
+  padding-bottom: 0.5rem; /* Extra padding at bottom */
+}
+
+.inactive-tabs-list.small {
+  max-height: 145px;
 }
 
 .inactive-tab-item {
@@ -950,6 +955,7 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  padding-right: 0.75rem; /* Prevent text hitting buttons */
 }
 
 .inactive-tab-time {

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -253,9 +253,20 @@
           </div>
 
           <div class="setting-group">
+            <div class="setting-header">
+              <label class="setting-label">Protect allowlisted domains</label>
+              <label class="toggle small">
+                <input type="checkbox" id="protectAllowlistToggle" checked />
+                <span class="slider"></span>
+              </label>
+            </div>
+            <p class="setting-hint">Allowlisted domains are never auto-closed</p>
+          </div>
+
+          <div class="setting-group">
             <div class="info-box">
               <span class="info-icon">💤</span>
-              <span class="info-text">The active tab is never auto-closed</span>
+              <span class="info-text">Active tab and last tab per window are never auto-closed</span>
             </div>
           </div>
 
@@ -298,6 +309,15 @@
             <div class="stat-card">
               <div class="stat-value" id="blockedTotal">0</div>
               <div class="stat-label">all time</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="stats-section">
+          <div class="stats-grid">
+            <div class="stat-card" style="grid-column: 1 / -1;">
+              <div class="stat-value" id="inactiveClosed">0</div>
+              <div class="stat-label">inactive tabs auto-closed</div>
             </div>
           </div>
         </div>

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -224,7 +224,7 @@
             <label class="setting-label">Close after (minutes)</label>
             <div class="stepper" id="inactiveStepper">
               <button class="stepper-btn" id="decreaseInactive">−</button>
-              <span class="stepper-value" id="inactiveMinutesValue">30</span>
+              <input type="number" class="stepper-input" id="inactiveMinutesInput" value="30" min="1">
               <button class="stepper-btn" id="increaseInactive">+</button>
             </div>
             <p class="setting-hint">Minimum: 1 min</p>

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -57,6 +57,7 @@
       <!-- Navigation Tabs -->
       <nav class="tabs">
         <button class="tab active" data-tab="settings">Settings</button>
+        <button class="tab" data-tab="inactive">Inactive</button>
         <button class="tab" data-tab="stats">Stats</button>
       </nav>
 
@@ -201,6 +202,68 @@
               <img src="images/logo.png" alt="" class="btn-enable-icon" />
               Activate Shield
             </button>
+          </div>
+        </div>
+      </main>
+
+      <!-- Inactive Tab -->
+      <main class="main tab-content" id="inactive-tab">
+        <div class="setting-group">
+          <div class="setting-header">
+            <label class="setting-label">Auto-close inactive tabs</label>
+            <label class="toggle small">
+              <input type="checkbox" id="inactiveToggle" />
+              <span class="slider"></span>
+            </label>
+          </div>
+          <p class="setting-hint">Close tabs that haven't been used in a while</p>
+        </div>
+
+        <div class="inactive-settings" id="inactiveSettingsContainer">
+          <div class="setting-group">
+            <label class="setting-label">Close after (minutes)</label>
+            <div class="stepper" id="inactiveStepper">
+              <button class="stepper-btn" id="decreaseInactive">−</button>
+              <span class="stepper-value" id="inactiveMinutesValue">30</span>
+              <button class="stepper-btn" id="increaseInactive">+</button>
+            </div>
+            <p class="setting-hint">Minimum: 1 min</p>
+          </div>
+
+          <div class="setting-group">
+            <div class="setting-header">
+              <label class="setting-label">Protect pinned tabs</label>
+              <label class="toggle small">
+                <input type="checkbox" id="protectPinnedToggle" checked />
+                <span class="slider"></span>
+              </label>
+            </div>
+            <p class="setting-hint">Pinned tabs are never auto-closed</p>
+          </div>
+
+          <div class="setting-group">
+            <div class="setting-header">
+              <label class="setting-label">Protect audible tabs</label>
+              <label class="toggle small">
+                <input type="checkbox" id="protectAudibleToggle" checked />
+                <span class="slider"></span>
+              </label>
+            </div>
+            <p class="setting-hint">Tabs playing audio are never auto-closed</p>
+          </div>
+
+          <div class="setting-group">
+            <div class="info-box">
+              <span class="info-icon">💤</span>
+              <span class="info-text">The active tab is never auto-closed</span>
+            </div>
+          </div>
+
+          <div class="setting-group">
+            <label class="setting-label">Tracked tabs</label>
+            <div class="inactive-tabs-list" id="inactiveTabsList">
+              <p class="setting-hint">No tracked tabs</p>
+            </div>
           </div>
         </div>
       </main>

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -267,16 +267,48 @@
             <label class="setting-label">Minimum tabs per window</label>
             <div class="stepper">
               <button class="stepper-btn" id="decreaseMinTabs">−</button>
-              <span class="stepper-value" id="minTabsValue">1</span>
+              <span class="stepper-value" id="minTabsValue">5</span>
               <button class="stepper-btn" id="increaseMinTabs">+</button>
             </div>
             <p class="setting-hint">Won't close below this threshold</p>
           </div>
 
           <div class="setting-group">
+            <div class="setting-header">
+              <label class="setting-label">Debounce activation</label>
+              <label class="toggle small">
+                <input type="checkbox" id="debounceToggle" checked />
+                <span class="slider"></span>
+              </label>
+            </div>
+            <p class="setting-hint">Wait 1s before resetting inactivity timer</p>
+          </div>
+
+          <div class="setting-group">
+            <label class="setting-label">Duplicate handling</label>
+            <select id="wrangleOptionSelect" class="select-input">
+              <option value="exactURLMatch">Remove exact URL duplicates</option>
+              <option value="hostnameAndTitleMatch">Remove same domain + title</option>
+              <option value="withDupes">Keep all duplicates</option>
+            </select>
+            <p class="setting-hint">How closed tabs are stored in the corral</p>
+          </div>
+
+          <div class="setting-group">
+            <div class="setting-header">
+              <label class="setting-label">Show corral count on badge</label>
+              <label class="toggle small">
+                <input type="checkbox" id="corralBadgeToggle" />
+                <span class="slider"></span>
+              </label>
+            </div>
+            <p class="setting-hint">Display closed tab count on extension icon</p>
+          </div>
+
+          <div class="setting-group">
             <div class="info-box">
               <span class="info-icon">💤</span>
-              <span class="info-text">Active tab is never auto-closed</span>
+              <span class="info-text">Active tab and internal pages are never closed</span>
             </div>
           </div>
 

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -295,17 +295,6 @@
           </div>
 
           <div class="setting-group">
-            <div class="setting-header">
-              <label class="setting-label">Show corral count on badge</label>
-              <label class="toggle small">
-                <input type="checkbox" id="corralBadgeToggle" />
-                <span class="slider"></span>
-              </label>
-            </div>
-            <p class="setting-hint">Display closed tab count on extension icon</p>
-          </div>
-
-          <div class="setting-group">
             <div class="info-box">
               <span class="info-icon">💤</span>
               <span class="info-text">Active tab and internal pages are never closed</span>

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -231,6 +231,26 @@
           </div>
 
           <div class="setting-group">
+            <label class="setting-label">Minimum tabs per window</label>
+            <div class="stepper">
+              <button class="stepper-btn" id="decreaseMinTabs">−</button>
+              <span class="stepper-value" id="minTabsValue">5</span>
+              <button class="stepper-btn" id="increaseMinTabs">+</button>
+            </div>
+            <p class="setting-hint">Won't close below this threshold</p>
+          </div>
+
+          <div class="setting-group">
+            <label class="setting-label">Activation delay (seconds)</label>
+            <div class="stepper">
+              <button class="stepper-btn" id="decreaseDebounce">−</button>
+              <span class="stepper-value" id="debounceValue">1</span>
+              <button class="stepper-btn" id="increaseDebounce">+</button>
+            </div>
+            <p class="setting-hint">Wait before resetting inactivity timer (0 = instant)</p>
+          </div>
+
+          <div class="setting-group">
             <div class="setting-header">
               <label class="setting-label">Protect pinned tabs</label>
               <label class="toggle small">
@@ -264,56 +284,24 @@
           </div>
 
           <div class="setting-group">
-            <label class="setting-label">Minimum tabs per window</label>
-            <div class="stepper">
-              <button class="stepper-btn" id="decreaseMinTabs">−</button>
-              <span class="stepper-value" id="minTabsValue">5</span>
-              <button class="stepper-btn" id="increaseMinTabs">+</button>
-            </div>
-            <p class="setting-hint">Won't close below this threshold</p>
-          </div>
-
-          <div class="setting-group">
-            <div class="setting-header">
-              <label class="setting-label">Debounce activation</label>
-              <label class="toggle small">
-                <input type="checkbox" id="debounceToggle" checked />
-                <span class="slider"></span>
-              </label>
-            </div>
-            <p class="setting-hint">Wait 1s before resetting inactivity timer</p>
-          </div>
-
-          <div class="setting-group">
-            <label class="setting-label">Duplicate handling</label>
-            <select id="wrangleOptionSelect" class="select-input">
-              <option value="exactURLMatch">Remove exact URL duplicates</option>
-              <option value="hostnameAndTitleMatch">Remove same domain + title</option>
-              <option value="withDupes">Keep all duplicates</option>
-            </select>
-            <p class="setting-hint">How closed tabs are stored in the corral</p>
-          </div>
-
-          <div class="setting-group">
             <div class="info-box">
               <span class="info-icon">💤</span>
-              <span class="info-text">Active tab and internal pages are never closed</span>
+              <span class="info-text">Active tab and system pages are never closed</span>
             </div>
           </div>
 
           <div class="setting-group">
             <label class="setting-label">Tracked tabs</label>
-            <div class="inactive-tabs-list" id="inactiveTabsList">
+            <div class="inactive-tabs-list small" id="inactiveTabsList">
               <p class="setting-hint">No tracked tabs</p>
             </div>
           </div>
 
           <div class="setting-group">
-            <div class="setting-header">
-              <label class="setting-label">Tab Corral</label>
-              <button class="btn-small" id="clearCorralBtn" style="font-size: 0.625rem; padding: 0.25rem 0.5rem;">Clear</button>
+            <div class="setting-header" style="margin-bottom: 0.5rem;">
+              <label class="setting-label">Recently closed</label>
+              <button class="btn-small" id="clearCorralBtn" style="font-size: 0.625rem; padding: 0.25rem 0.5rem; margin-right: 0.5rem;">Clear</button>
             </div>
-            <p class="setting-hint">Closed tabs you can restore</p>
             <div class="inactive-tabs-list" id="corralList">
               <p class="setting-hint">No closed tabs</p>
             </div>

--- a/TabCap Extension/popup.html
+++ b/TabCap Extension/popup.html
@@ -264,9 +264,19 @@
           </div>
 
           <div class="setting-group">
+            <label class="setting-label">Minimum tabs per window</label>
+            <div class="stepper">
+              <button class="stepper-btn" id="decreaseMinTabs">−</button>
+              <span class="stepper-value" id="minTabsValue">1</span>
+              <button class="stepper-btn" id="increaseMinTabs">+</button>
+            </div>
+            <p class="setting-hint">Won't close below this threshold</p>
+          </div>
+
+          <div class="setting-group">
             <div class="info-box">
               <span class="info-icon">💤</span>
-              <span class="info-text">Active tab and last tab per window are never auto-closed</span>
+              <span class="info-text">Active tab is never auto-closed</span>
             </div>
           </div>
 
@@ -274,6 +284,17 @@
             <label class="setting-label">Tracked tabs</label>
             <div class="inactive-tabs-list" id="inactiveTabsList">
               <p class="setting-hint">No tracked tabs</p>
+            </div>
+          </div>
+
+          <div class="setting-group">
+            <div class="setting-header">
+              <label class="setting-label">Tab Corral</label>
+              <button class="btn-small" id="clearCorralBtn" style="font-size: 0.625rem; padding: 0.25rem 0.5rem;">Clear</button>
+            </div>
+            <p class="setting-hint">Closed tabs you can restore</p>
+            <div class="inactive-tabs-list" id="corralList">
+              <p class="setting-hint">No closed tabs</p>
             </div>
           </div>
         </div>

--- a/TabCap Extension/popup.js
+++ b/TabCap Extension/popup.js
@@ -51,6 +51,7 @@ let settings = {
   inactiveMinutes: 30,
   protectPinned: true,
   protectAudible: true,
+  protectAllowlist: true,
 };
 
 let stats = {
@@ -108,6 +109,8 @@ function initElements() {
     increaseInactive: document.getElementById("increaseInactive"),
     protectPinnedToggle: document.getElementById("protectPinnedToggle"),
     protectAudibleToggle: document.getElementById("protectAudibleToggle"),
+    protectAllowlistToggle: document.getElementById("protectAllowlistToggle"),
+    inactiveClosedStat: document.getElementById("inactiveClosed"),
     inactiveTabsList: document.getElementById("inactiveTabsList"),
     frictionModal: document.getElementById("frictionModal"),
     modalTitle: document.getElementById("modalTitle"),
@@ -212,6 +215,8 @@ function updateUI() {
     elements.protectPinnedToggle.checked = settings.protectPinned;
   if (elements.protectAudibleToggle)
     elements.protectAudibleToggle.checked = settings.protectAudible;
+  if (elements.protectAllowlistToggle)
+    elements.protectAllowlistToggle.checked = settings.protectAllowlist;
 
   // Stats
   if (elements.currentStreak)
@@ -223,6 +228,8 @@ function updateUI() {
     elements.blockedWeek.textContent = stats.blockedWeek;
   if (elements.blockedTotal)
     elements.blockedTotal.textContent = stats.blockedTotal;
+  if (elements.inactiveClosedStat)
+    elements.inactiveClosedStat.textContent = stats.inactiveClosed || 0;
 }
 
 function updateLockUI() {
@@ -550,6 +557,14 @@ function setupEventListeners() {
   if (elements.protectAudibleToggle) {
     elements.protectAudibleToggle.addEventListener("change", async (e) => {
       settings.protectAudible = e.target.checked;
+      await saveSettings();
+    });
+  }
+
+  // Protect allowlist toggle
+  if (elements.protectAllowlistToggle) {
+    elements.protectAllowlistToggle.addEventListener("change", async (e) => {
+      settings.protectAllowlist = e.target.checked;
       await saveSettings();
     });
   }

--- a/TabCap Extension/popup.js
+++ b/TabCap Extension/popup.js
@@ -56,7 +56,6 @@ let settings = {
   corralMax: 100,
   debounceOnActivated: true,
   wrangleOption: "exactURLMatch",
-  showCorralBadge: false,
 };
 
 let stats = {
@@ -124,7 +123,6 @@ function initElements() {
     clearCorralBtn: document.getElementById("clearCorralBtn"),
     wrangleOptionSelect: document.getElementById("wrangleOptionSelect"),
     debounceToggle: document.getElementById("debounceToggle"),
-    corralBadgeToggle: document.getElementById("corralBadgeToggle"),
     frictionModal: document.getElementById("frictionModal"),
     modalTitle: document.getElementById("modalTitle"),
     modalMessage: document.getElementById("modalMessage"),
@@ -236,8 +234,6 @@ function updateUI() {
     elements.wrangleOptionSelect.value = settings.wrangleOption || "exactURLMatch";
   if (elements.debounceToggle)
     elements.debounceToggle.checked = settings.debounceOnActivated !== false;
-  if (elements.corralBadgeToggle)
-    elements.corralBadgeToggle.checked = settings.showCorralBadge || false;
 
   // Stats
   if (elements.currentStreak)
@@ -622,14 +618,6 @@ function setupEventListeners() {
   if (elements.debounceToggle) {
     elements.debounceToggle.addEventListener("change", async (e) => {
       settings.debounceOnActivated = e.target.checked;
-      await saveSettings();
-    });
-  }
-
-  // Corral badge toggle
-  if (elements.corralBadgeToggle) {
-    elements.corralBadgeToggle.addEventListener("change", async (e) => {
-      settings.showCorralBadge = e.target.checked;
       await saveSettings();
     });
   }

--- a/TabCap Extension/popup.js
+++ b/TabCap Extension/popup.js
@@ -305,7 +305,13 @@ function renderDomains() {
   settings.allowlist.forEach((domain, index) => {
     const tag = document.createElement("div");
     tag.className = "domain-tag";
-    tag.innerHTML = `<span>${domain}</span><button data-index="${index}">×</button>`;
+    const span = document.createElement("span");
+    span.textContent = domain;
+    const btn = document.createElement("button");
+    btn.dataset.index = index;
+    btn.textContent = "×";
+    tag.appendChild(span);
+    tag.appendChild(btn);
     elements.domainsList.appendChild(tag);
   });
 }
@@ -589,8 +595,9 @@ function setupEventListeners() {
   // Min tabs stepper (range: 0-50, Tab Wrangler allows 0+)
   if (elements.decreaseMinTabs) {
     elements.decreaseMinTabs.addEventListener("click", async () => {
-      if ((settings.minTabs || 0) > 0) {
-        settings.minTabs = (settings.minTabs || 5) - 1;
+      const current = settings.minTabs != null ? settings.minTabs : 5;
+      if (current > 0) {
+        settings.minTabs = current - 1;
         await saveSettings();
         updateUI();
       }
@@ -598,8 +605,9 @@ function setupEventListeners() {
   }
   if (elements.increaseMinTabs) {
     elements.increaseMinTabs.addEventListener("click", async () => {
-      if ((settings.minTabs || 0) < 50) {
-        settings.minTabs = (settings.minTabs || 5) + 1;
+      const current = settings.minTabs != null ? settings.minTabs : 5;
+      if (current < 50) {
+        settings.minTabs = current + 1;
         await saveSettings();
         updateUI();
       }

--- a/TabCap/TabCap.xcodeproj/project.pbxproj
+++ b/TabCap/TabCap.xcodeproj/project.pbxproj
@@ -435,7 +435,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 7QX6PLCF2C;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -450,7 +450,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -470,7 +470,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 7QX6PLCF2C;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -485,7 +485,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/TabCap/TabCap.xcodeproj/project.pbxproj
+++ b/TabCap/TabCap.xcodeproj/project.pbxproj
@@ -508,7 +508,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 7QX6PLCF2C;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -525,7 +525,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -551,7 +551,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 7QX6PLCF2C;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
Implement a new "Inactive" tab in the popup UI that allows users to
automatically close tabs that haven't been accessed for a configurable
number of minutes. Uses browser.alarms API for reliable periodic checks
in MV3 service workers, and manually tracks tab activity timestamps
since Safari doesn't support tab.lastAccessed.

Features:
- Configurable inactivity timeout (1-480 minutes)
- Protection for pinned and audible tabs (toggleable)
- Active tab is never auto-closed
- Tracked tabs list with countdown timers in popup
- Activity state persisted to storage for service worker restarts

https://claude.ai/code/session_01FQMCBnXxWFB7NYLuKzvs1z